### PR TITLE
Removes ids of the returned json

### DIFF
--- a/account/src/main/java/io/trivial/models/service/KeyOrganizationServiceModel.java
+++ b/account/src/main/java/io/trivial/models/service/KeyOrganizationServiceModel.java
@@ -1,8 +1,6 @@
 package io.trivial.models.service;
 
-import io.trivial.models.entites.BaseEntity;
-
-public class KeyOrganizationServiceModel extends BaseEntity {
+public class KeyOrganizationServiceModel {
 
     private String organizationName;
     private String organizationKey;

--- a/account/src/main/java/io/trivial/models/view/KeyOrganizationViewModel.java
+++ b/account/src/main/java/io/trivial/models/view/KeyOrganizationViewModel.java
@@ -1,8 +1,6 @@
 package io.trivial.models.view;
 
-import io.trivial.models.entites.BaseEntity;
-
-public class KeyOrganizationViewModel extends BaseEntity {
+public class KeyOrganizationViewModel {
 
     private String organizationName;
     private String organizationKey;

--- a/account/src/main/java/io/trivial/models/view/UserOrganizationViewModel.java
+++ b/account/src/main/java/io/trivial/models/view/UserOrganizationViewModel.java
@@ -2,7 +2,7 @@ package io.trivial.models.view;
 
 import java.util.List;
 
-public class UserOrganizationViewModel extends BaseViewModel {
+public class UserOrganizationViewModel {
 
     private List<KeyOrganizationViewModel> keysOrganization;
 


### PR DESCRIPTION
The idea of this PR is to simply remove the ids in the KeyOrganization models coming from the BaseEntity.
It was discussed with @plm012  and @ANeshkova.
Closes #163  