### PR TITLE
Add banner to help debug MySQL issues

### DIFF
--- a/landingPage/server/src/main/java/com/jointrivial/server/ServerApplication.java
+++ b/landingPage/server/src/main/java/com/jointrivial/server/ServerApplication.java
@@ -2,12 +2,30 @@ package com.jointrivial.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.beans.factory.BeanCreationException;
+import java.sql.SQLException;
 
 @SpringBootApplication
 public class ServerApplication {
 
 	public static void main(String[] args) {
-		SpringApplication.run(ServerApplication.class, args);
+        try {
+            SpringApplication.run(ServerApplication.class, args);
+        } catch (BeanCreationException exception) {
+            System.err.println("Unhandled exception: " + exception);
+            // See if MySQL is involved in the failure.
+            if (exception.contains(SQLException.class)) {
+                System.err.println("############################################################");
+                System.err.println("#                                                          #");
+                System.err.println("#       Error: Cannot connect to MySQL;                    #");
+                System.err.println("#       search logs for \"Communications link failure\"      #");
+                System.err.println("#         (indicates no running MySQL server),             #");
+                System.err.println("#       or search logs for \"Access denied for user\"        #");
+                System.err.println("#         (indicates TRIVIAL_DB_PASSWORD is not set).      #");
+                System.err.println("#                                                          #");
+                System.err.println("############################################################");
+            }
+        }
 	}
 
 }


### PR DESCRIPTION
The proper exception cannot be caught, because it is thrown inside
framework code. Our best effort is to catch a "BeanCreationException"
and see if it contains any MySQLExceptions.

If so, print a banner that hints at possible solutions.